### PR TITLE
use string instead of bool

### DIFF
--- a/helm/_default.yaml
+++ b/helm/_default.yaml
@@ -33,7 +33,7 @@ envVariables:
       name: ai-secrets
 
 - name: LANGSMITH_TRACING
-  value: true
+  value: "true"
 
 - name: LANGSMITH_ENDPOINT
   value: "https://api.smith.langchain.com"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Changed `LANGSMITH_TRACING` value type from boolean to string.

- Ensured consistency in environment variable value types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_default.yaml</strong><dd><code>Corrected `LANGSMITH_TRACING` value type in environment variables</code></dd></summary>
<hr>

helm/_default.yaml

<li>Updated <code>LANGSMITH_TRACING</code> environment variable value from <code>true</code> <br>(boolean) to <code>"true"</code> (string).<br> <li> Ensured proper type usage for environment variable values.


</details>


  </td>
  <td><a href="https://github.com/bringg/data-agents-service/pull/26/files#diff-820041c0910d502efd1b9d120526d76a686b01d45e619d901a3cb6d39701870a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>